### PR TITLE
style: reset the img default width

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -6,10 +6,6 @@ html, body {
   -webkit-text-size-adjust: 100%;
 }
 
-img {
-  max-width: none;
-}
-
 em img {
   max-width: 100%;
   margin-left: 0;


### PR DESCRIPTION
Currently the image will overflow in smaller screen. This PR fixes it by removing the `max-width: none.`

<img width="870" alt="Screenshot 2024-05-26 at 8 41 56 PM" src="https://github.com/mlc-ai/jekyll-theme-mlc/assets/23090573/6338cdd5-0479-4930-ac52-b56fb3e2db31">

After:
<img width="647" alt="Screenshot 2024-05-26 at 8 42 08 PM" src="https://github.com/mlc-ai/jekyll-theme-mlc/assets/23090573/0b0dddfe-078e-4df4-819a-be4e098f230b">

